### PR TITLE
カメラロール選択時に一番上（古い）のサムネイルから表示されてしまう

### DIFF
--- a/QBImagePicker/Info.plist
+++ b/QBImagePicker/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.0</string>
+	<string>3.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -108,8 +108,12 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
         // when presenting as a .FormSheet on iPad, the frame is not correct until just after viewWillAppear:
         // dispatching to the main thread waits one run loop until the frame is update and the layout is complete
         dispatch_async(dispatch_get_main_queue(), ^{
-            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.fetchResult.count - 1) inSection:0];
-            [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionBottom animated:NO];
+            CGFloat contentHeight = self.collectionView.contentSize.height;
+            CGFloat frameHeight = self.collectionView.frame.size.height + self.collectionView.contentInset.bottom;
+            if (contentHeight > frameHeight) {
+                CGPoint offset = CGPointMake(self.collectionView.contentOffset.x, contentHeight - frameHeight);
+                [self.collectionView setContentOffset:offset animated:NO];
+            }
         });
     }
 }

--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -109,7 +109,7 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
         // dispatching to the main thread waits one run loop until the frame is update and the layout is complete
         dispatch_async(dispatch_get_main_queue(), ^{
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.fetchResult.count - 1) inSection:0];
-            [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
+            [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionBottom animated:NO];
         });
     }
 }

--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -411,7 +411,10 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
                     
                     NSIndexSet *changedIndexes = [collectionChanges changedIndexes];
                     if ([changedIndexes count]) {
-                        [self.collectionView reloadItemsAtIndexPaths:[changedIndexes qb_indexPathsFromIndexesWithSection:0]];
+                        // https://github.com/questbeat/QBImagePicker/pull/180
+                        NSMutableIndexSet *changedWithoutRemovalsIndexes = [changedIndexes mutableCopy];
+                        [changedWithoutRemovalsIndexes removeIndexes:removedIndexes];
+                        [self.collectionView reloadItemsAtIndexPaths:[changedWithoutRemovalsIndexes qb_indexPathsFromIndexesWithSection:0]];
                     }
                 } completion:NULL];
             }

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -58,6 +58,19 @@
     return self;
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    // 呼び出し元でNOをセットしていた場合に一番古いファイルへスクロールする不具合があるため、ImagePicker内でのみ有効化する
+    [[UINavigationBar appearance] setTranslucent:YES];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [[UINavigationBar appearance] setTranslucent:NO];
+}
+
 - (void)setUpAlbumsViewController
 {
     // Add QBAlbumsViewController as a child

--- a/QBImagePicker/QBImagePickerController.m
+++ b/QBImagePicker/QBImagePickerController.m
@@ -58,19 +58,6 @@
     return self;
 }
 
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
-    // 呼び出し元でNOをセットしていた場合に一番古いファイルへスクロールする不具合があるため、ImagePicker内でのみ有効化する
-    [[UINavigationBar appearance] setTranslucent:YES];
-}
-
-- (void)viewWillDisappear:(BOOL)animated
-{
-    [super viewWillDisappear:animated];
-    [[UINavigationBar appearance] setTranslucent:NO];
-}
-
 - (void)setUpAlbumsViewController
 {
     // Add QBAlbumsViewController as a child


### PR DESCRIPTION
- 呼び出し元でisTranslucent = falseの状態のままカメラロール画面を表示させると、一番上のサムネイルから表示してしまう
  - カメラロールの表示位置をCollectionViewのcontentSize・frameを比較して指定するよう修正
- QBImagePickerの最終リリース以後に修正されたままになっていたコミットがありましたが、crash回避のために必要と思しきものだったので含めてリリースします
